### PR TITLE
Enable anonymous login with Viewer role

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,8 @@ services:
       - GF_SECURITY_ADMIN_USER=${ADMIN_USER}
       - GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
     restart: unless-stopped
     ports:
       - 3000:3000


### PR DESCRIPTION
Now you should be able to view the dashboards without logging in. Anonymous users should not be able to edit the dashboards themselves.

I'm not sure if this setup is applicable to everyone's Minecraft servers, or if this is something we just want with CNB MC. Anyway, here it is. 